### PR TITLE
Add all unique hashes to existing files

### DIFF
--- a/find_unique_checksums.py
+++ b/find_unique_checksums.py
@@ -71,5 +71,9 @@ for version, files in sorted(releases.items()):
     filename, hash = ordered_files[0]
     all_versions_for_this_hash = md5sums[filename][hash]
     fingerprints[filename][hash] = ', '.join(sorted(all_versions_for_this_hash))
+
+for filename in fingerprints.keys():
+    for hash, release in unique_sums[filename].items():
+        fingerprints[filename][hash] = release
     
 print json.dumps(fingerprints, indent=4)


### PR DESCRIPTION
After we determine which files to include, add all unique hashes to
these file entries. Some versions are now listed multiple times. This
reduces the number of files we need to request and gives better results
if a site has modified some files.
